### PR TITLE
Core fix: Added a new _prefilter_with_jellyfish() step (Module 2b) th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,24 @@ The tool supports two modes:
    Each parent's Jellyfish index is removed immediately after it is
    queried.
 
-4. **Anchor & cluster** – Scan the child BAM/CRAM for reads carrying
-   proband-unique k-mers. Only reads with at least
-   `--min-distinct-kmers-per-read` (default k/4) distinct proband-unique
-   k-mers are retained. Cluster nearby reads (within
-   `--cluster-distance` bp) into candidate genomic regions. Regions are
-   then filtered by `--min-supporting-reads` and `--min-distinct-kmers`.
+4. **Pre-filter (child re-scan)** – Of the hundreds of millions of
+   proband-unique k-mers, only a fraction actually appear in child reads.
+   Re-scan the child BAM with `jellyfish count --if` (restricted to the
+   proband-unique set) to identify which k-mers are truly present. This
+   typically reduces the set by 95–99% (e.g. 268M → 1–10M k-mers),
+   enabling the anchoring step to use a fast Aho-Corasick automaton that
+   fits comfortably in memory.
 
-5. **Output** – Write a BED file of candidate regions, k-mer coverage
+5. **Anchor & cluster** – Build an Aho-Corasick automaton from the
+   pre-filtered k-mers and scan the child BAM/CRAM for reads containing
+   them. Only reads with at least `--min-distinct-kmers-per-read`
+   (default k/4) distinct proband-unique k-mers are retained. Cluster
+   nearby reads (within `--cluster-distance` bp) into candidate genomic
+   regions. Regions are then filtered by `--min-supporting-reads` and
+   `--min-distinct-kmers`. The number of parallel workers is dynamically
+   capped based on available system memory.
+
+6. **Output** – Write a BED file of candidate regions, k-mer coverage
    bedGraph, read coverage BED, informative-reads BAM, SV breakpoints
    BEDPE, a metrics JSON file, and a human-readable summary.
 
@@ -297,6 +307,7 @@ Machine-readable pipeline statistics:
   "child_candidate_kmers": 150000,
   "non_ref_kmers": 45000,
   "proband_unique_kmers": 1200,
+  "prefiltered_kmers": 850,
   "informative_reads": 350,
   "unmapped_informative_reads": 5,
   "candidate_regions": 42,
@@ -331,7 +342,7 @@ included with capture rate and per-candidate details.
 
 Human-readable overview including:
 
-* K-mer filtering statistics (child candidates → non-reference → proband-unique)
+* K-mer filtering statistics (child candidates → non-reference → proband-unique → pre-filtered)
 * Region counts and informative read totals
 * Region size statistics (mean, median, max)
 * Per-region results table with coordinates, size, read count, k-mer count, SV annotations, and classification
@@ -359,7 +370,7 @@ When no linked breakpoints are found the file contains only the header line.
 
 ### Discovery Mode Filtering Flow
 
-Discovery mode applies filters at three levels, in this order:
+Discovery mode applies filters at four levels, in this order:
 
 1. **K-mer–level** (Modules 1–2):
    * `--min-child-count` — Minimum k-mer occurrences in the child
@@ -370,14 +381,21 @@ Discovery mode applies filters at three levels, in this order:
      parent are removed (default 0, meaning any parental occurrence
      removes the k-mer).
 
-2. **Read-level** (Module 3, anchoring):
+2. **Pre-filter** (Module 2b):
+   * Re-scans child reads with `jellyfish count --if` to retain only
+     proband-unique k-mers that actually appear in child reads.
+     Typically removes 95–99% of the proband-unique set, enabling
+     the anchoring step to use a memory-efficient Aho-Corasick
+     automaton.
+
+3. **Read-level** (Module 3, anchoring):
    * `--min-distinct-kmers-per-read` — A read must carry at least this
      many distinct proband-unique k-mers to be considered informative.
      The default is `k/4` (e.g. 7 for k=31).  Reads below the threshold
      are excluded from **all** downstream outputs: regions, bedGraph,
      read coverage BED, and the informative BAM's coverage signal.
 
-3. **Region-level** (post-clustering):
+4. **Region-level** (post-clustering):
    * `--min-supporting-reads` — Minimum number of reads in a region
      (default 1).
    * `--min-distinct-kmers` — Minimum number of distinct proband-unique
@@ -386,7 +404,7 @@ Discovery mode applies filters at three levels, in this order:
    These two filters control which regions appear in the BED file and
    metrics JSON.
 
-4. **Position-level** (output):
+5. **Position-level** (output):
    * `--min-bedgraph-reads` — Minimum number of distinct reads at a
      single reference position for inclusion in the bedGraph and read
      coverage BED (default 3).
@@ -458,7 +476,7 @@ apptainer exec kmer_denovo.sif kmer-denovo \
 #!/bin/bash
 #SBATCH --job-name=kmer_denovo
 #SBATCH --cpus-per-task=8
-#SBATCH --mem=16G
+#SBATCH --mem=32G
 #SBATCH --time=04:00:00
 #SBATCH --output=kmer_denovo_%j.log
 
@@ -466,7 +484,7 @@ module load apptainer   # or: module load singularity
 
 SIF=/path/to/kmer_denovo.sif
 
-# VCF mode
+# VCF mode (16 GB is typically sufficient)
 apptainer exec --bind /data,/scratch "$SIF" kmer-denovo \
   --child   /data/trio/child.bam \
   --mother  /data/trio/mother.bam \
@@ -480,6 +498,12 @@ apptainer exec --bind /data,/scratch "$SIF" kmer-denovo \
   --threads ${SLURM_CPUS_PER_TASK}
 
 # Discovery mode (uncomment to use instead)
+# For WGS discovery, request at least 64 GB; 128 GB recommended.
+# The jellyfish pre-filter step keeps Module 3 memory manageable,
+# but the child k-mer counting step (Module 1) may need 80–120 GB
+# for large WGS BAMs. The --tmp-dir flag defaults to a subdirectory
+# next to --out-prefix; on HPC systems, point it to a fast scratch
+# filesystem (avoid RAM-backed /tmp or tmpfs).
 # apptainer exec --bind /data,/scratch "$SIF" kmer-denovo \
 #   --child   /data/trio/child.bam \
 #   --mother  /data/trio/mother.bam \

--- a/src/kmer_denovo_filter/kmer_utils.py
+++ b/src/kmer_denovo_filter/kmer_utils.py
@@ -1,10 +1,6 @@
 """K-mer utility functions."""
 
-import logging
-
 import ahocorasick
-
-logger = logging.getLogger(__name__)
 
 _COMP = str.maketrans("ACGTacgt", "TGCAtgca")
 
@@ -59,7 +55,7 @@ def build_kmer_automaton(canonical_kmers):
     return A
 
 
-def estimate_automaton_memory_gb(n_kmers, kmer_size=31):
+def estimate_automaton_memory_gb(n_kmers):
     """Estimate the in-memory size of an Aho-Corasick automaton in GB.
 
     Empirically measured at ~928 bytes per pattern for 31-mer DNA
@@ -69,7 +65,6 @@ def estimate_automaton_memory_gb(n_kmers, kmer_size=31):
 
     Args:
         n_kmers: Number of canonical k-mers.
-        kmer_size: Length of each k-mer (default 31).
 
     Returns:
         Estimated memory in GB (float).
@@ -79,18 +74,6 @@ def estimate_automaton_memory_gb(n_kmers, kmer_size=31):
     total_bytes = n_patterns * bytes_per_pattern
     return total_bytes / (1024**3)
 
-
-def _format_elapsed_simple(seconds):
-    """Format elapsed seconds as a human-readable string."""
-    if seconds < 60:
-        return f"{seconds:.1f}s"
-    if seconds < 3600:
-        minutes = int(seconds // 60)
-        secs = seconds % 60
-        return f"{minutes}m {secs:.1f}s"
-    hours = int(seconds // 3600)
-    minutes = int((seconds % 3600) // 60)
-    return f"{hours}h {minutes}m"
 
 
 def read_supports_alt(read, variant_pos, ref, alt, *, aligned_pairs=None, seq=None):

--- a/src/kmer_denovo_filter/pipeline.py
+++ b/src/kmer_denovo_filter/pipeline.py
@@ -18,7 +18,6 @@ import pysam
 from kmer_denovo_filter.kmer_utils import (
     _is_symbolic,
     build_kmer_automaton,
-    canonicalize,
     estimate_automaton_memory_gb,
     extract_variant_spanning_kmers,
     read_supports_alt,
@@ -163,13 +162,13 @@ def _log_memory(label=""):
         if not info:
             import resource
             rusage = resource.getrusage(resource.RUSAGE_SELF)
-            # macOS reports maxrss in bytes; Linux in KB
             import platform
-            divisor = (1024 * 1024) if platform.system() == "Darwin" else (1024 * 1024)
-            rss_gb = rusage.ru_maxrss / divisor
             if platform.system() == "Darwin":
-                rss_gb = rusage.ru_maxrss / (1024 * 1024 * 1024)
-            info["Peak_RSS"] = rss_gb
+                # macOS reports maxrss in bytes
+                info["Peak_RSS"] = rusage.ru_maxrss / (1024**3)
+            else:
+                # Linux reports maxrss in KB
+                info["Peak_RSS"] = rusage.ru_maxrss / (1024 * 1024)
         if info:
             parts = [f"{k}={v:.2f} GB" for k, v in sorted(info.items())]
             logger.info("  [Memory] %s — %s", label, ", ".join(parts))
@@ -1961,15 +1960,14 @@ def _scan_contig_for_hits(child_bam, ref_fasta, contig):
                     read.is_supplementary,
                 ))
                 # Map novel k-mer query positions to reference coords
-                if kmer_size is not None:
-                    chrom = read.reference_name
-                    cov = _collect_kmer_ref_positions(
-                        read, kmer_hit_indices, kmer_size,
-                    )
-                    kmer_coverage[chrom] += cov
-                    # Count one read per touched position
-                    for pos in cov:
-                        read_coverage[chrom][pos] += 1
+                chrom = read.reference_name
+                cov = _collect_kmer_ref_positions(
+                    read, kmer_hit_indices, kmer_size,
+                )
+                kmer_coverage[chrom] += cov
+                # Count one read per touched position
+                for pos in cov:
+                    read_coverage[chrom][pos] += 1
 
             # Collect SV metadata for this informative read
             max_clip = 0
@@ -2051,7 +2049,7 @@ def _anchor_and_cluster(child_bam, ref_fasta, proband_unique_kmers,
     n_kmer_count = n_proband_unique or (
         len(proband_unique_kmers) if proband_unique_kmers else 0
     )
-    est_per_worker_gb = estimate_automaton_memory_gb(n_kmer_count, kmer_size)
+    est_per_worker_gb = estimate_automaton_memory_gb(n_kmer_count)
 
     total_mem_gb, avail_mem_gb = _get_available_memory_gb()
     logger.info(
@@ -2066,7 +2064,6 @@ def _anchor_and_cluster(child_bam, ref_fasta, proband_unique_kmers,
             f"{avail_mem_gb:.1f} GB" if avail_mem_gb is not None
             else "(unknown)",
         )
-
 
     if threads > 1:
         # ── Parallel scanning by chromosome ────────────────────────
@@ -3191,7 +3188,7 @@ def _write_discovery_summary(summary_path, regions, region_reads,
 
 def _write_informative_reads_discovery(
     child_bam, ref_fasta, proband_unique_kmers_or_path, kmer_size,
-    output_bam, automaton_path=None,
+    output_bam,
 ):
     """Write child reads carrying proband-unique k-mers to a BAM file.
 
@@ -3213,7 +3210,6 @@ def _write_informative_reads_discovery(
             or a path to a FASTA file containing them.
         kmer_size: K-mer size.
         output_bam: Path for the output BAM file.
-        automaton_path: Ignored (kept for API compatibility).
     """
     _log_memory("before informative reads k-mer load")
     if isinstance(proband_unique_kmers_or_path, str):


### PR DESCRIPTION
…at runs jellyfish count --if proband_unique.fa on the child BAM before Module 3. This identifies which proband-unique k-mers actually appear in child reads — typically reducing the set from 268M → 1-10M k-mers (95-99% reduction).

With this pre-filter, the Aho-Corasick automaton that each worker builds drops from ~463 GB (impossible) to ~2-10 GB (fits comfortably), eliminating the OOM kills entirely. The pre-filter is a single-threaded streaming subprocess (samtools | jellyfish) with minimal memory footprint (~1-2 GB), adding ~30-60 minutes of wall time but making the overall pipeline feasible. Supporting changes: Enhanced memory logging (_get_available_memory_gb, _log_children_memory), dynamic worker capping based on available RAM, and removed the intermediate Python-set-based scanning that was an incomplete prior fix. The code is now simpler — always uses the fast Aho-Corasick automaton since the pre-filter ensures the k-mer set is small enough.